### PR TITLE
Avoid resolving the ip address early in the configuration.

### DIFF
--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -40,8 +40,8 @@ public class GelfConfiguration {
      * @param port The port of the GELF-enabled server
      */
     public GelfConfiguration(final String hostname, final int port) {
-        this.hostname = hostname;
-        this.port = port;
+        this.hostname = checkHostname(hostname);
+        this.port = checkPort(port);
     }
 
     /**
@@ -231,5 +231,24 @@ public class GelfConfiguration {
     public GelfConfiguration sendBufferSize(final int sendBufferSize) {
         this.sendBufferSize = sendBufferSize;
         return this;
+    }
+
+    private String checkHostname(final String hostname) {
+        if (hostname == null) {
+            throw new IllegalArgumentException("hostname can't be null");
+        }
+        if (hostname.trim().isEmpty()) {
+            throw new IllegalArgumentException("hostname can't be empty");
+        }
+        return hostname;
+    }
+
+    private int checkPort(final int port) {
+        // While 0 is a valid port number, it doesn't make sense here.
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("port out of range: " + port);
+        }
+
+        return port;
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -24,7 +24,8 @@ import java.net.InetSocketAddress;
 public class GelfConfiguration {
     private static final int DEFAULT_PORT = 12201;
     private static final String DEFAULT_HOSTNAME = "127.0.0.1";
-    private final InetSocketAddress remoteAddress;
+    private final String hostname;
+    private final int port;
     private GelfTransports transport = GelfTransports.TCP;
     private int queueSize = 512;
     private int reconnectDelay = 500;
@@ -33,12 +34,23 @@ public class GelfConfiguration {
     private int sendBufferSize = -1;
 
     /**
+     * Creates a new configuration with the given hostname and port.
+     *
+     * @param hostname The hostname of the GELF-enabled server
+     * @param port The port of the GELF-enabled server
+     */
+    public GelfConfiguration(final String hostname, final int port) {
+        this.hostname = hostname;
+        this.port = port;
+    }
+
+    /**
      * Creates a new configuration with the given remote address.
      *
      * @param remoteAddress The {@link java.net.InetSocketAddress} of the GELF server
      */
     public GelfConfiguration(final InetSocketAddress remoteAddress) {
-        this.remoteAddress = remoteAddress;
+        this(remoteAddress.getHostString(), remoteAddress.getPort());
     }
 
     /**
@@ -47,7 +59,7 @@ public class GelfConfiguration {
      * @param hostname The hostname of the GELF-enabled server
      */
     public GelfConfiguration(final String hostname) {
-        this(new InetSocketAddress(hostname, DEFAULT_PORT));
+        this(hostname, DEFAULT_PORT);
     }
 
     /**
@@ -56,14 +68,32 @@ public class GelfConfiguration {
      * @param port The port of the GELF-enabled server
      */
     public GelfConfiguration(final int port) {
-        this(new InetSocketAddress(DEFAULT_HOSTNAME, port));
+        this(DEFAULT_HOSTNAME, port);
     }
 
     /**
      * Creates a new configuration with the local hostname ("127.0.0.1") and the default port (12201).
      */
     public GelfConfiguration() {
-        this(new InetSocketAddress(DEFAULT_HOSTNAME, DEFAULT_PORT));
+        this(DEFAULT_HOSTNAME, DEFAULT_PORT);
+    }
+
+    /**
+     * Get the hostname of the GELF server.
+     *
+     * @return the hostname of the GELF server.
+     */
+    public String getHostname() {
+        return hostname;
+    }
+
+    /**
+     * Get the port of the GELF server.
+     *
+     * @return the port of the GELF server.
+     */
+    public int getPort() {
+        return port;
     }
 
     /**
@@ -72,7 +102,8 @@ public class GelfConfiguration {
      * @return the remote address of the GELF server.
      */
     public InetSocketAddress getRemoteAddress() {
-        return remoteAddress;
+        // Always create a new InetSocketAddress to ensure that the hostname is resolved to an ip address again.
+        return new InetSocketAddress(hostname, port);
     }
 
     /**

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -31,6 +31,36 @@ public class GelfConfigurationTest {
         this.config = new GelfConfiguration();
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructorNullHostname() throws Exception {
+        new GelfConfiguration(null, 12201);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructorEmptyHostname() throws Exception {
+        new GelfConfiguration("  ", 12201);
+    }
+
+    @Test
+    public void testConstructorMinPort() throws Exception {
+        new GelfConfiguration("127.0.0.1", 1);
+    }
+
+    @Test
+    public void testConstructorMaxPort() throws Exception {
+        new GelfConfiguration("127.0.0.1", 65535);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructorSmallerMinPort() throws Exception {
+        new GelfConfiguration("127.0.0.1", 0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructorLargerMaxPort() throws Exception {
+        new GelfConfiguration("127.0.0.1", 65536);
+    }
+
     @Test
     public void testQueueSize() {
         // Check default value.

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -44,20 +44,20 @@ public class GelfConfigurationTest {
     @Test
     public void testRemoteAddress() {
         assertEquals(new InetSocketAddress("127.0.0.1", 12201), config.getRemoteAddress());
-        assertEquals(InetSocketAddress.createUnresolved("10.0.0.1", 12345),
-                new GelfConfiguration(InetSocketAddress.createUnresolved("10.0.0.1", 12345)).getRemoteAddress());
+        assertEquals(new InetSocketAddress("10.0.0.1", 12345),
+                new GelfConfiguration(new InetSocketAddress("10.0.0.1", 12345)).getRemoteAddress());
     }
 
     @Test
     public void testPort() {
-        assertEquals(12201, config.getRemoteAddress().getPort());
-        assertEquals(10000, new GelfConfiguration(10000).getRemoteAddress().getPort());
+        assertEquals(12201, config.getPort());
+        assertEquals(10000, new GelfConfiguration(10000).getPort());
     }
 
     @Test
     public void testHostName() {
-        assertEquals("127.0.0.1", config.getRemoteAddress().getHostString());
-        assertEquals("example.com", new GelfConfiguration("example.com").getRemoteAddress().getHostName());
+        assertEquals("127.0.0.1", config.getHostname());
+        assertEquals("example.com", new GelfConfiguration("example.com").getHostname());
     }
 
     @Test


### PR DESCRIPTION
Until this, we took an InetSocketAddress and reused that in
getRemoteAddress(). This is problematic if the ip address for the
hostname changes between re-connects.

We now store the hostname and port in the configuration object and
create a new InetSocketAddress for every call to getRemoteAddress().

See Graylog2/graylog2-server#882.