### PR TITLE
Allow setting GELF level to null to remote the level from the message

### DIFF
--- a/src/main/java/org/graylog2/gelfclient/GelfMessageBuilder.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfMessageBuilder.java
@@ -109,6 +109,8 @@ public class GelfMessageBuilder {
     /**
      * Set the level (priority) of the {@link GelfMessage}.
      *
+     * Can be set to {@code null} to remove the (optional) level from the {@link GelfMessage}.
+     *
      * @param level the {@link GelfMessageLevel} of the {@link GelfMessage}.
      * @return {@code this} instance
      */
@@ -159,15 +161,11 @@ public class GelfMessageBuilder {
             throw new IllegalArgumentException("version must not be null!");
         }
 
-        if (level == null) {
-            throw new IllegalArgumentException("level must not be null!");
-        }
-
         final GelfMessage gelfMessage = new GelfMessage(message, host, version);
 
         gelfMessage.setLevel(level);
 
-        if(fullMessage != null) {
+        if (fullMessage != null) {
             gelfMessage.setFullMessage(fullMessage);
         }
 

--- a/src/main/java/org/graylog2/gelfclient/encoder/GelfMessageJsonEncoder.java
+++ b/src/main/java/org/graylog2/gelfclient/encoder/GelfMessageJsonEncoder.java
@@ -83,7 +83,9 @@ public class GelfMessageJsonEncoder extends MessageToMessageEncoder<GelfMessage>
             jg.writeNumberField("timestamp", message.getTimestamp());
             jg.writeStringField("host", message.getHost());
             jg.writeStringField("short_message", message.getMessage());
-            jg.writeNumberField("level", message.getLevel().getNumericLevel());
+            if (message.getLevel() != null) {
+                jg.writeNumberField("level", message.getLevel().getNumericLevel());
+            }
 
             if(null != message.getFullMessage()) {
                 jg.writeStringField("full_message", message.getFullMessage());

--- a/src/test/java/org/graylog2/gelfclient/GelfMessageBuilderTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfMessageBuilderTest.java
@@ -21,6 +21,8 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotSame;
 
@@ -42,6 +44,7 @@ public class GelfMessageBuilderTest {
         assertEquals("example.org", gelfMessage.getHost());
         assertEquals(GelfMessageVersion.V1_1, gelfMessage.getVersion());
         assertEquals(0.0d, gelfMessage.getTimestamp());
+        assertEquals(GelfMessageLevel.ALERT, gelfMessage.getLevel());
         assertEquals("bar", gelfMessage.getAdditionalFields().get("_foo"));
         assertEquals(123, gelfMessage.getAdditionalFields().get("_baz"));
         assertEquals(456.789d, gelfMessage.getAdditionalFields().get("_qux"));
@@ -84,8 +87,20 @@ public class GelfMessageBuilderTest {
         new GelfMessageBuilder("Test", "localhost", null).build();
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testMissingLevelThrowsException() throws Exception {
-        new GelfMessageBuilder("Test").level(null).build();
+    @Test
+    public void testWithNullLevel() throws Exception {
+        final GelfMessageBuilder builder = new GelfMessageBuilder("Test").level(null);
+
+        boolean error = false;
+        final GelfMessage message;
+        try {
+            message = builder.build();
+
+            assertNull(message.getLevel());
+        } catch (Exception e) {
+            error = true;
+        }
+
+        assertFalse(error, "Null level should not throw an error");
     }
 }

--- a/src/test/java/org/graylog2/gelfclient/GelfMessageBuilderTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfMessageBuilderTest.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotSame;
@@ -89,18 +88,8 @@ public class GelfMessageBuilderTest {
 
     @Test
     public void testWithNullLevel() throws Exception {
-        final GelfMessageBuilder builder = new GelfMessageBuilder("Test").level(null);
+        final GelfMessage message= new GelfMessageBuilder("Test").level(null).build();
 
-        boolean error = false;
-        final GelfMessage message;
-        try {
-            message = builder.build();
-
-            assertNull(message.getLevel());
-        } catch (Exception e) {
-            error = true;
-        }
-
-        assertFalse(error, "Null level should not throw an error");
+        assertNull(message.getLevel());
     }
 }

--- a/src/test/java/org/graylog2/gelfclient/GelfMessageTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfMessageTest.java
@@ -174,8 +174,8 @@ public class GelfMessageTest {
 
         assertNull(message.getLevel());
         assertTrue(message.toString().contains("level=\"null\""));
-        assertTrue(message.equals(message2));
-        assertFalse(message.equals(messageNoNull));
+        assertEquals(message, message2);
+        assertNotEquals(message, messageNoNull);
         assertEquals(message.hashCode(), message2.hashCode());
         assertNotEquals(message.hashCode(), messageNoNull.hashCode());
     }

--- a/src/test/java/org/graylog2/gelfclient/GelfMessageTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfMessageTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -155,5 +156,27 @@ public class GelfMessageTest {
         assertTrue(message.toString().contains("123456"));
         assertTrue(message.toString().contains("ALERT"));
         assertFalse(message.toString().contains("additional_key"));
+    }
+
+    @Test
+    public void testWorksWithNullLevel() throws Exception {
+        final GelfMessage message = new GelfMessage("hello");
+        final GelfMessage message2 = new GelfMessage("hello");
+        final GelfMessage messageNoNull = new GelfMessage("hello");
+
+        // Make sure timestamp is the same for all objects.
+        message.setTimestamp(1.0);
+        message2.setTimestamp(1.0);
+        messageNoNull.setTimestamp(1.0);
+
+        message.setLevel(null);
+        message2.setLevel(null);
+
+        assertNull(message.getLevel());
+        assertTrue(message.toString().contains("level=\"null\""));
+        assertTrue(message.equals(message2));
+        assertFalse(message.equals(messageNoNull));
+        assertEquals(message.hashCode(), message2.hashCode());
+        assertNotEquals(message.hashCode(), messageNoNull.hashCode());
     }
 }


### PR DESCRIPTION
Makes it possible to send a GELF message without the (optional) level.

Removing the level by default might be nicer but that would be a breaking change.