### PR TITLE
Add option to configure keep-alive for TCP connections

### DIFF
--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -35,6 +35,7 @@ public class GelfConfiguration {
     private int reconnectDelay = 500;
     private int connectTimeout = 1000;
     private boolean tcpNoDelay = false;
+    private boolean tcpKeepAlive = false;
     private int sendBufferSize = -1;
 
     /**
@@ -289,6 +290,15 @@ public class GelfConfiguration {
      */
     public GelfConfiguration tcpNoDelay(final boolean tcpNoDelay) {
         this.tcpNoDelay = tcpNoDelay;
+        return this;
+    }
+
+    public boolean isTcpKeepAlive() {
+        return tcpKeepAlive;
+    }
+
+    public GelfConfiguration tcpKeepAlive(final boolean tcpKeepAlive) {
+        this.tcpKeepAlive = tcpKeepAlive;
         return this;
     }
 

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -59,6 +59,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
                 .channel(NioSocketChannel.class)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, config.getConnectTimeout())
                 .option(ChannelOption.TCP_NODELAY, config.isTcpNoDelay())
+                .option(ChannelOption.SO_KEEPALIVE, config.isTcpKeepAlive())
                 .remoteAddress(config.getRemoteAddress())
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -27,6 +27,7 @@ final GelfConfiguration config = new GelfConfiguration(new InetSocketAddress("ex
         .connectTimeout(5000)
         .reconnectDelay(1000)
         .tcpNoDelay(true)
+        .tcpKeepAlive(true)
         .sendBufferSize(32768);
 
 final GelfTransport transport = GelfTransports.create(config);

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -167,6 +167,16 @@ public class GelfConfigurationTest {
     }
 
     @Test
+    public void testtcpKeepAlive() {
+        // Check default value.
+        assertEquals(false, config.isTcpKeepAlive());
+
+        config.tcpKeepAlive(true);
+
+        assertEquals(true, config.isTcpKeepAlive());
+    }
+
+    @Test
     public void testSendBufferSize() {
         // Check default value.
         assertEquals(-1, config.getSendBufferSize());

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -159,21 +159,21 @@ public class GelfConfigurationTest {
     @Test
     public void testtcpNoDelay() {
         // Check default value.
-        assertEquals(false, config.isTcpNoDelay());
+        assertFalse(config.isTcpNoDelay());
 
         config.tcpNoDelay(true);
 
-        assertEquals(true, config.isTcpNoDelay());
+        assertTrue(config.isTcpNoDelay());
     }
 
     @Test
     public void testtcpKeepAlive() {
         // Check default value.
-        assertEquals(false, config.isTcpKeepAlive());
+        assertFalse(config.isTcpKeepAlive());
 
         config.tcpKeepAlive(true);
 
-        assertEquals(true, config.isTcpKeepAlive());
+        assertTrue(config.isTcpKeepAlive());
     }
 
     @Test


### PR DESCRIPTION
The default is false to keep previous behaviour.

Fixes #13