### PR TITLE
Limit the number of allow inflight network writeAndFlush operations

### DIFF
--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -37,6 +37,7 @@ public class GelfConfiguration {
     private boolean tcpNoDelay = false;
     private boolean tcpKeepAlive = false;
     private int sendBufferSize = -1;
+    private int maxInflightSends = 512;
 
     /**
      * Creates a new configuration with the given hostname and port.
@@ -342,5 +343,13 @@ public class GelfConfiguration {
         }
 
         return port;
+    }
+
+    public int getMaxInflightSends() {
+        return maxInflightSends;
+    }
+
+    public void setMaxInflightSends(int maxInflightSends) {
+        this.maxInflightSends = maxInflightSends;
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -345,11 +345,25 @@ public class GelfConfiguration {
         return port;
     }
 
+    /**
+     * Get the number of max queued network operations.
+     *
+     * @return max number of queued network operations
+     * @since 1.4.0
+     */
     public int getMaxInflightSends() {
         return maxInflightSends;
     }
 
-    public void setMaxInflightSends(int maxInflightSends) {
+    /**
+     * Set the number of max queued network operations.
+     *
+     * @param maxInflightSends max number of queued network operations
+     * @return {@code this} instance
+     * @since 1.4.0
+     */
+    public GelfConfiguration maxInflightSends(int maxInflightSends) {
         this.maxInflightSends = maxInflightSends;
+        return this;
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -314,7 +314,7 @@ public class GelfConfiguration {
     }
 
     /**
-     * Get the size of the socket send buffer in bytes.
+     * Set the size of the socket send buffer in bytes.
      *
      * @param sendBufferSize the size of the socket send buffer in bytes.
      *                       A value of {@code -1} deactivates the socket send buffer.

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfSenderThread.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfSenderThread.java
@@ -17,6 +17,8 @@
 package org.graylog2.gelfclient.transport;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import org.graylog2.gelfclient.GelfMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +26,12 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * The main event thread used by the {@link org.graylog2.gelfclient.transport.GelfTransport}s.
@@ -37,20 +43,34 @@ public class GelfSenderThread {
     private final AtomicBoolean keepRunning = new AtomicBoolean(true);
     private final Thread senderThread;
     private Channel channel;
+    private final int maxInflightSends;
 
     /**
      * Creates a new sender thread with the given {@link BlockingQueue} as source of messages.
      *
-     * @param queue the {@link BlockingQueue} used as source of {@link org.graylog2.gelfclient.GelfMessage}s
+     * @param queue the {@link BlockingQueue} used as source of {@link GelfMessage}s
+     * @param maxInflightSends the maximum number of outstanding network writes/flushes before the sender spins
      */
-    public GelfSenderThread(final BlockingQueue<GelfMessage> queue) {
+    public GelfSenderThread(final BlockingQueue<GelfMessage> queue, int maxInflightSends) {
+        this.maxInflightSends = maxInflightSends;
         this.lock = new ReentrantLock();
         this.connectedCond = lock.newCondition();
+
+        if (maxInflightSends <= 0) {
+            throw new IllegalArgumentException("maxInflightSends must be larger than 0");
+        }
 
         this.senderThread = new Thread(new Runnable() {
             @Override
             public void run() {
                 GelfMessage gelfMessage = null;
+                final AtomicInteger inflightSends = new AtomicInteger(0);
+                final ChannelFutureListener inflightListener = new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        inflightSends.decrementAndGet();
+                    }
+                };
 
                 while (keepRunning.get()) {
                     // wait until we are connected to the graylog2 server before polling log events from the queue
@@ -76,9 +96,16 @@ public class GelfSenderThread {
                             // but if we aren't connected anymore, we'll have already pulled an event from the queue,
                             // which we keep hanging around in this thread and in the next loop iteration will block until we are connected again.
                             if (gelfMessage != null && channel != null && channel.isActive()) {
+                                // Do not allow more than "maxInflightSends" concurrent writes in netty, to avoid having netty buffer
+                                // excessively when faced with slower consumers
+                                while (inflightSends.get() > GelfSenderThread.this.maxInflightSends) {
+                                    sleepUninterruptibly(1, MICROSECONDS);
+                                }
+                                inflightSends.incrementAndGet();
+
                                 // Write the GELF message to the pipeline. The protocol specific channel handler
                                 // will take care of encoding.
-                                channel.writeAndFlush(gelfMessage);
+                                channel.writeAndFlush(gelfMessage).addListener(inflightListener);
                                 gelfMessage = null;
                             }
                         } catch (InterruptedException e) {
@@ -95,6 +122,34 @@ public class GelfSenderThread {
 
         this.senderThread.setDaemon(true);
         this.senderThread.setName("GelfSenderThread-" + senderThread.getId());
+    }
+
+    /**
+     * Copied from Guava for convenience.
+     *
+     * Invokes {@code unit.}{@link TimeUnit#sleep(long) sleep(sleepFor)}
+     * uninterruptibly.
+     */
+    private static void sleepUninterruptibly(long sleepFor, TimeUnit unit) {
+        boolean interrupted = false;
+        try {
+            long remainingNanos = unit.toNanos(sleepFor);
+            long end = System.nanoTime() + remainingNanos;
+            while (true) {
+                try {
+                    // TimeUnit.sleep() treats negative timeouts just like zero.
+                    NANOSECONDS.sleep(remainingNanos);
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    remainingNanos = end - System.nanoTime();
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     public void start(Channel channel) {

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -54,7 +54,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        final GelfSenderThread senderThread = new GelfSenderThread(queue);
+        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -52,7 +52,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        final GelfSenderThread senderThread = new GelfSenderThread(queue);
+        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/util/Uninterruptibles.java
+++ b/src/main/java/org/graylog2/gelfclient/util/Uninterruptibles.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graylog2.gelfclient.util;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class Uninterruptibles {
+    /**
+     * Copied from Guava for convenience.
+     *
+     * Invokes {@code unit.}{@link TimeUnit#sleep(long) sleep(sleepFor)}
+     * uninterruptibly.
+     */
+    public static void sleepUninterruptibly(long sleepFor, TimeUnit unit) {
+        boolean interrupted = false;
+        try {
+            long remainingNanos = unit.toNanos(sleepFor);
+            long end = System.nanoTime() + remainingNanos;
+            while (true) {
+                try {
+                    // TimeUnit.sleep() treats negative timeouts just like zero.
+                    NANOSECONDS.sleep(remainingNanos);
+                    return;
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                    remainingNanos = end - System.nanoTime();
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -185,4 +185,11 @@ public class GelfConfigurationTest {
 
         assertEquals(32768, config.getSendBufferSize());
     }
+
+    @Test
+    public void testMaxInflightSends() {
+        assertEquals(512, config.getMaxInflightSends());
+        config.setMaxInflightSends(1024);
+        assertEquals(1024, config.getMaxInflightSends());
+    }
 }

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -189,7 +189,7 @@ public class GelfConfigurationTest {
     @Test
     public void testMaxInflightSends() {
         assertEquals(512, config.getMaxInflightSends());
-        config.setMaxInflightSends(1024);
+        assertEquals(config.maxInflightSends(1024), config);
         assertEquals(1024, config.getMaxInflightSends());
     }
 }

--- a/src/test/java/org/graylog2/gelfclient/Issue22.java
+++ b/src/test/java/org/graylog2/gelfclient/Issue22.java
@@ -1,0 +1,35 @@
+package org.graylog2.gelfclient;
+
+import org.graylog2.gelfclient.transport.GelfTransport;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.util.Date;
+
+public class Issue22 {
+
+    @Test(enabled = false)
+    public void shouldNotOOM() throws InterruptedException {
+        final GelfMessageBuilder builder = new GelfMessageBuilder("", "GELF-CLIENT-TEST").level(GelfMessageLevel.INFO);
+
+        final GelfConfiguration config = new GelfConfiguration(new InetSocketAddress("localhost", 12202))
+                .transport(GelfTransports.TCP)
+                .tcpKeepAlive(true)
+                .queueSize(512)
+                .connectTimeout(5000)
+                .reconnectDelay(5000)
+                .tcpNoDelay(true)
+                .sendBufferSize(1024);
+
+        final GelfTransport transport = GelfTransports.create(config);
+
+        for (int i = 0; i < 2_000_000; i++) {
+            final GelfMessage message = builder.message(i + " Test " + new Date()).additionalField("foo", i + " foo " + i).build();
+            transport.send(message);
+//            if (i % 1_000 == 0) System.out.println(i +" - "+ new Date());
+        }
+
+        Thread.sleep(5 * 60_000);
+    }
+
+}

--- a/src/test/java/org/graylog2/gelfclient/Issue22.java
+++ b/src/test/java/org/graylog2/gelfclient/Issue22.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 TORCH GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.graylog2.gelfclient;
 
 import org.graylog2.gelfclient.transport.GelfTransport;


### PR DESCRIPTION
Without limiting netty would happily create more and more internal buffers, using large amounts of memory.
That memory pressure could lead to OOM situations or very high GC times when faced with either fast producers or slow consumers (or worst case both).

The number of maximum inflight sends is configurable and by default limited to 512 operations.

fixes #22