### PR TITLE
Allow choice for compression algorithm in GELF UDP

### DIFF
--- a/src/main/java/org/graylog2/gelfclient/Compression.java
+++ b/src/main/java/org/graylog2/gelfclient/Compression.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Graylog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.graylog2.gelfclient;
+
+public enum Compression {
+    GZIP, ZLIB, NONE
+}

--- a/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
+++ b/src/main/java/org/graylog2/gelfclient/GelfConfiguration.java
@@ -28,6 +28,7 @@ public class GelfConfiguration {
     private final String hostname;
     private final int port;
     private GelfTransports transport = GelfTransports.TCP;
+    private Compression compression = Compression.GZIP;
     private int queueSize = 512;
     private boolean tlsEnabled = false;
     private File tlsTrustCertChainFile = null;
@@ -130,6 +131,26 @@ public class GelfConfiguration {
      */
     public GelfConfiguration transport(final GelfTransports transport) {
         this.transport = transport;
+        return this;
+    }
+
+    /**
+     * Get the compression algorithm used for GELF UDP.
+     *
+     * @return the compression algorithm used for GELF UDP
+     */
+    public Compression getCompression() {
+        return compression;
+    }
+
+    /**
+     * Set the compression algorithm used for GELF UDP.
+     *
+     * @param compression the compression algorithm used for GELF UDP
+     * @return {@code this} instance
+     */
+    public GelfConfiguration compression(final Compression compression) {
+        this.compression = compression;
         return this;
     }
 

--- a/src/main/java/org/graylog2/gelfclient/encoder/GelfCompressionGzipEncoder.java
+++ b/src/main/java/org/graylog2/gelfclient/encoder/GelfCompressionGzipEncoder.java
@@ -28,7 +28,7 @@ import java.util.zip.GZIPOutputStream;
 /**
  * A Netty channel handler which compresses messages using a {@link GZIPOutputStream}.
  */
-public class GelfCompressionEncoder extends MessageToMessageEncoder<ByteBuf> {
+public class GelfCompressionGzipEncoder extends MessageToMessageEncoder<ByteBuf> {
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
         try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();

--- a/src/main/java/org/graylog2/gelfclient/encoder/GelfCompressionZlibEncoder.java
+++ b/src/main/java/org/graylog2/gelfclient/encoder/GelfCompressionZlibEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Graylog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graylog2.gelfclient.encoder;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.zip.DeflaterOutputStream;
+
+/**
+ * A Netty channel handler which compresses messages using a {@link DeflaterOutputStream}.
+ */
+public class GelfCompressionZlibEncoder extends MessageToMessageEncoder<ByteBuf> {
+    @Override
+    protected void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             final DeflaterOutputStream stream = new DeflaterOutputStream(bos)) {
+
+            stream.write(msg.array());
+            stream.finish();
+
+            out.add(Unpooled.wrappedBuffer(bos.toByteArray()));
+        }
+    }
+}

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -26,7 +26,8 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import org.graylog2.gelfclient.GelfConfiguration;
-import org.graylog2.gelfclient.encoder.GelfCompressionEncoder;
+import org.graylog2.gelfclient.encoder.GelfCompressionGzipEncoder;
+import org.graylog2.gelfclient.encoder.GelfCompressionZlibEncoder;
 import org.graylog2.gelfclient.encoder.GelfMessageChunkEncoder;
 import org.graylog2.gelfclient.encoder.GelfMessageJsonEncoder;
 import org.graylog2.gelfclient.encoder.GelfMessageUdpEncoder;
@@ -61,7 +62,16 @@ public class GelfUdpTransport extends AbstractGelfTransport {
                     protected void initChannel(Channel ch) throws Exception {
                         ch.pipeline().addLast(new GelfMessageUdpEncoder(config.getRemoteAddress()));
                         ch.pipeline().addLast(new GelfMessageChunkEncoder());
-                        ch.pipeline().addLast(new GelfCompressionEncoder());
+                        switch (config.getCompression()) {
+                            case GZIP:
+                                ch.pipeline().addLast(new GelfCompressionGzipEncoder());
+                                break;
+                            case ZLIB:
+                                ch.pipeline().addLast(new GelfCompressionZlibEncoder());
+                                break;
+                            case NONE:
+                            default:
+                        }
                         ch.pipeline().addLast(new GelfMessageJsonEncoder());
                         ch.pipeline().addLast(new SimpleChannelInboundHandler<DatagramPacket>() {
                             @Override

--- a/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
+++ b/src/test/java/org/graylog2/gelfclient/GelfConfigurationTest.java
@@ -201,4 +201,13 @@ public class GelfConfigurationTest {
 
         assertEquals(512, config.getThreads());
     }
+
+    @Test
+    public void testCompression() {
+        assertEquals(Compression.GZIP, config.getCompression());
+
+        config.compression(Compression.NONE);
+
+        assertEquals(Compression.NONE, config.getCompression());
+    }
 }

--- a/src/test/java/org/graylog2/gelfclient/encoder/GelfCompressionGzipEncoderTest.java
+++ b/src/test/java/org/graylog2/gelfclient/encoder/GelfCompressionGzipEncoderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 TORCH GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graylog2.gelfclient.encoder;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class GelfCompressionGzipEncoderTest {
+
+    @Test
+    public void testEncode() throws Exception {
+        final EmbeddedChannel channel = new EmbeddedChannel(new GelfCompressionGzipEncoder());
+        final String message = "Test string";
+
+        assertTrue(channel.writeOutbound(Unpooled.wrappedBuffer(message.getBytes(StandardCharsets.UTF_8))));
+        assertTrue(channel.finish());
+
+        final ByteBufInputStream byteBufInputStream = new ByteBufInputStream((ByteBuf) channel.readOutbound());
+        final GZIPInputStream gzipInputStream = new GZIPInputStream(byteBufInputStream);
+
+        byte[] bytes = new byte[message.length()];
+
+        assertEquals(message.length(), gzipInputStream.read(bytes, 0, message.length()));
+        assertEquals(message, new String(bytes, StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/org/graylog2/gelfclient/encoder/GelfCompressionZlibEncoderTest.java
+++ b/src/test/java/org/graylog2/gelfclient/encoder/GelfCompressionZlibEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 TORCH GmbH
+ * Copyright 2018 Graylog, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,27 +23,27 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.testng.annotations.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class GelfCompressionEncoderTest {
+public class GelfCompressionZlibEncoderTest {
 
     @Test
     public void testEncode() throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new GelfCompressionEncoder());
+        final EmbeddedChannel channel = new EmbeddedChannel(new GelfCompressionZlibEncoder());
         final String message = "Test string";
 
         assertTrue(channel.writeOutbound(Unpooled.wrappedBuffer(message.getBytes(StandardCharsets.UTF_8))));
         assertTrue(channel.finish());
 
         final ByteBufInputStream byteBufInputStream = new ByteBufInputStream((ByteBuf) channel.readOutbound());
-        final GZIPInputStream gzipInputStream = new GZIPInputStream(byteBufInputStream);
+        final InflaterInputStream zlibInputStream = new InflaterInputStream(byteBufInputStream);
 
         byte[] bytes = new byte[message.length()];
 
-        assertEquals(message.length(), gzipInputStream.read(bytes, 0, message.length()));
+        assertEquals(message.length(), zlibInputStream.read(bytes, 0, message.length()));
         assertEquals(message, new String(bytes, StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
This change set adds support for choosing the compression algorithm (None, GZIP, or ZLib)
used in GELF UDP transports.

The default is GZIP (which was the only available compression algorithm before).

Closes #32