### PR TITLE
Update Netty to version 4.1.31.FINAL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.25.Final</version>
+            <version>4.1.31.Final</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This update was performed, because a Netty 4 dependency was added in graylog-server version 2.5 for backport of the DNS Lookup adapter (see https://github.com/Graylog2/graylog2-server/pull/5274).

@bernd and I will review together in Houston