### PR TITLE
Flush queued messages before shutting down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: java
 after_success:

--- a/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
@@ -39,7 +39,7 @@ public abstract class AbstractGelfTransport implements GelfTransport {
     protected final BlockingQueue<GelfMessage> queue;
 
     private final EventLoopGroup workerGroup;
-    GelfSenderThread senderThread;
+    final GelfSenderThread senderThread;
 
     /**
      * Creates a new GELF transport with the given configuration and {@link java.util.concurrent.BlockingQueue}.
@@ -51,6 +51,7 @@ public abstract class AbstractGelfTransport implements GelfTransport {
         this.config = config;
         this.queue = queue;
         this.workerGroup = new NioEventLoopGroup(config.getThreads(), new DefaultThreadFactory(getClass(), true));
+        this.senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
         createBootstrap(workerGroup);
     }
 

--- a/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
@@ -124,7 +124,7 @@ public abstract class AbstractGelfTransport implements GelfTransport {
     @Override
     public void flushAndStopSynchronously(int waitDuration, TimeUnit timeUnit, int retries) {
 
-        if (senderThreadReference != null) {
+        if (senderThreadReference.get() != null) {
             senderThreadReference.get().flushSynchronously(waitDuration, timeUnit, retries);
         }
         stop();

--- a/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
@@ -41,7 +41,8 @@ public abstract class AbstractGelfTransport implements GelfTransport {
 
     private final EventLoopGroup workerGroup;
 
-    // Use an ato
+    // Use an AtomicReference to manage thread safe access to the senderThread.
+    // A new senderThread instance is set each time a reconnect is attempted.
     final AtomicReference<GelfSenderThread> senderThreadReference;
 
     /**

--- a/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/AbstractGelfTransport.java
@@ -39,6 +39,7 @@ public abstract class AbstractGelfTransport implements GelfTransport {
     protected final BlockingQueue<GelfMessage> queue;
 
     private final EventLoopGroup workerGroup;
+    GelfSenderThread senderThread;
 
     /**
      * Creates a new GELF transport with the given configuration and {@link java.util.concurrent.BlockingQueue}.
@@ -110,5 +111,17 @@ public abstract class AbstractGelfTransport implements GelfTransport {
     @Override
     public void stop() {
         workerGroup.shutdownGracefully().syncUninterruptibly();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void flushAndStopSynchronously(int waitDuration, TimeUnit timeUnit, int retries) {
+
+        if (senderThread != null) {
+            senderThread.flushSynchronously(waitDuration, timeUnit, retries);
+        }
+        stop();
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfSenderThread.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfSenderThread.java
@@ -45,8 +45,8 @@ public class GelfSenderThread {
     private final Thread senderThread;
     private Channel channel;
     private final int maxInflightSends;
-    private BlockingQueue<GelfMessage> queue;
-    private AtomicInteger inflightSends;
+    private final BlockingQueue<GelfMessage> queue;
+    private final AtomicInteger inflightSends;
 
     /**
      * Creates a new sender thread with the given {@link BlockingQueue} as source of messages.

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -55,7 +55,12 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThreadReference.set(new GelfSenderThread(queue, config.getMaxInflightSends()));
+
+        // Use local senderThread variable within this method to ensure that the same thread is always returned.
+        // Even if the reference is updated by another thread, the channelActive channelInactive callbacks
+        // will still reference the original thread.
+        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThreadReference.set(senderThread);
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)
@@ -102,13 +107,13 @@ public class GelfTcpTransport extends AbstractGelfTransport {
 
                             @Override
                             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                                senderThreadReference.get().start(ctx.channel());
+                                senderThread.start(ctx.channel());
                             }
 
                             @Override
                             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
                                 LOG.info("Channel disconnected!");
-                                senderThreadReference.get().stop();
+                                senderThread.stop();
                                 scheduleReconnect(ctx.channel().eventLoop());
                             }
 

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -55,7 +55,6 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 public class GelfTcpTransport extends AbstractGelfTransport {
     private static final Logger LOG = LoggerFactory.getLogger(GelfTcpTransport.class);
 
+    GelfSenderThread senderThread;
+
     /**
      * Creates a new TCP GELF transport.
      *
@@ -55,7 +57,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)
@@ -135,5 +137,14 @@ public class GelfTcpTransport extends AbstractGelfTransport {
                 }
             }
         });
+    }
+
+    @Override
+    public void flushAndStop() {
+
+        if (senderThread != null) {
+            senderThread.flushAndStop();
+        }
+        super.stop();
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -43,8 +43,6 @@ import org.slf4j.LoggerFactory;
 public class GelfTcpTransport extends AbstractGelfTransport {
     private static final Logger LOG = LoggerFactory.getLogger(GelfTcpTransport.class);
 
-    GelfSenderThread senderThread;
-
     /**
      * Creates a new TCP GELF transport.
      *
@@ -57,7 +55,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        super.senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)
@@ -137,14 +135,5 @@ public class GelfTcpTransport extends AbstractGelfTransport {
                 }
             }
         });
-    }
-
-    @Override
-    public void flushAndStop() {
-
-        if (senderThread != null) {
-            senderThread.flushSynchronously();
-        }
-        super.stop();
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -55,6 +55,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
+        senderThreadReference.set(new GelfSenderThread(queue, config.getMaxInflightSends()));
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)
@@ -101,13 +102,13 @@ public class GelfTcpTransport extends AbstractGelfTransport {
 
                             @Override
                             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                                senderThread.start(ctx.channel());
+                                senderThreadReference.get().start(ctx.channel());
                             }
 
                             @Override
                             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
                                 LOG.info("Channel disconnected!");
-                                senderThread.stop();
+                                senderThreadReference.get().stop();
                                 scheduleReconnect(ctx.channel().eventLoop());
                             }
 

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -143,7 +143,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     public void flushAndStop() {
 
         if (senderThread != null) {
-            senderThread.flushAndStop();
+            senderThread.flushSynchronously();
         }
         super.stop();
     }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTcpTransport.java
@@ -55,7 +55,7 @@ public class GelfTcpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        super.senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioSocketChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
@@ -47,7 +47,7 @@ public interface GelfTransport {
     void stop();
 
     /**
-     * Stops the transport after sending all enqueued messages.
+     * Stops the transport after flushing/sending all enqueued messages.
      * Should be used to gracefully shutdown the backend.
      */
     void flushAndStop();

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
@@ -45,4 +45,10 @@ public interface GelfTransport {
      * Stops the transport. Should be used to gracefully shutdown the backend.
      */
     void stop();
+
+    /**
+     * Stops the transport after sending all enqueued messages.
+     * Should be used to gracefully shutdown the backend.
+     */
+    void flushAndStop();
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
@@ -59,7 +59,8 @@ public interface GelfTransport {
      *
      * @param waitDuration the wait duration.
      * @param timeUnit the time unit for the {@code waitDuration}.
-     * @param retries the number of times to retry and wait for messages to flush.
+     * @param retries the number of times to retry and wait for messages to flush. Zero retries indicates that
+     *                one initial attempt will be made.
      */
     void flushAndStopSynchronously(int waitDuration, TimeUnit timeUnit, int retries);
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfTransport.java
@@ -18,6 +18,8 @@ package org.graylog2.gelfclient.transport;
 
 import org.graylog2.gelfclient.GelfMessage;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * A common interface for all GELF network transports.
  */
@@ -42,13 +44,22 @@ public interface GelfTransport {
     boolean trySend(GelfMessage message);
 
     /**
-     * Stops the transport. Should be used to gracefully shutdown the backend.
+     * Stops the transport. Can be used to gracefully shutdown the backend.
      */
     void stop();
 
     /**
-     * Stops the transport after flushing/sending all enqueued messages.
-     * Should be used to gracefully shutdown the backend.
+     * Blocks and stops the transport after flushing/sending all enqueued messages.
+     * Blocking occurs until either all messages are flushed, or the indicated {@code waitDuration}, {@code timeUnit}
+     * and {@code retries} have elapsed.
+     *
+     * Each retry waits for the indicated {@code waitDuration} and {@code timeUnit} again.
+     *
+     * This can be used to gracefully shutdown the backend.
+     *
+     * @param waitDuration the wait duration.
+     * @param timeUnit the time unit for the {@code waitDuration}.
+     * @param retries the number of times to retry and wait for messages to flush.
      */
-    void flushAndStop();
+    void flushAndStopSynchronously(int waitDuration, TimeUnit timeUnit, int retries);
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
 public class GelfUdpTransport extends AbstractGelfTransport {
     private static final Logger LOG = LoggerFactory.getLogger(GelfUdpTransport.class);
 
-    GelfSenderThread senderThread;
-
     /**
      * Creates a new UDP GELF transport.
      *
@@ -55,7 +53,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        super.senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -55,7 +55,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        super.senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)
@@ -104,14 +104,5 @@ public class GelfUdpTransport extends AbstractGelfTransport {
         }
 
         bootstrap.bind(0);
-    }
-
-    @Override
-    public void flushAndStop() {
-
-        if (senderThread != null) {
-            senderThread.flushSynchronously();
-        }
-        super.stop();
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 public class GelfUdpTransport extends AbstractGelfTransport {
     private static final Logger LOG = LoggerFactory.getLogger(GelfUdpTransport.class);
 
+    GelfSenderThread senderThread;
+
     /**
      * Creates a new UDP GELF transport.
      *
@@ -53,7 +55,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)
@@ -102,5 +104,14 @@ public class GelfUdpTransport extends AbstractGelfTransport {
         }
 
         bootstrap.bind(0);
+    }
+
+    @Override
+    public void flushAndStop() {
+
+        if (senderThread != null) {
+            senderThread.flushAndStop();
+        }
+        super.stop();
     }
 }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -53,6 +53,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
+        senderThreadReference.set(new GelfSenderThread(queue, config.getMaxInflightSends()));
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)
@@ -80,12 +81,12 @@ public class GelfUdpTransport extends AbstractGelfTransport {
 
                             @Override
                             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                                senderThread.start(ctx.channel());
+                                senderThreadReference.get().start(ctx.channel());
                             }
 
                             @Override
                             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-                                senderThread.stop();
+                                senderThreadReference.get().stop();
                             }
 
                             @Override

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -110,7 +110,7 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     public void flushAndStop() {
 
         if (senderThread != null) {
-            senderThread.flushAndStop();
+            senderThread.flushSynchronously();
         }
         super.stop();
     }

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -53,7 +53,6 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)

--- a/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
+++ b/src/main/java/org/graylog2/gelfclient/transport/GelfUdpTransport.java
@@ -53,7 +53,12 @@ public class GelfUdpTransport extends AbstractGelfTransport {
     @Override
     protected void createBootstrap(final EventLoopGroup workerGroup) {
         final Bootstrap bootstrap = new Bootstrap();
-        senderThreadReference.set(new GelfSenderThread(queue, config.getMaxInflightSends()));
+
+        // Use local senderThread variable within this method to ensure that the same thread is always returned.
+        // Even if the reference is updated by another thread, the channelActive channelInactive callbacks
+        // will still reference the original thread.
+        final GelfSenderThread senderThread = new GelfSenderThread(queue, config.getMaxInflightSends());
+        senderThreadReference.set(senderThread);
 
         bootstrap.group(workerGroup)
                 .channel(NioDatagramChannel.class)
@@ -81,12 +86,12 @@ public class GelfUdpTransport extends AbstractGelfTransport {
 
                             @Override
                             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                                senderThreadReference.get().start(ctx.channel());
+                                senderThread.start(ctx.channel());
                             }
 
                             @Override
                             public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-                                senderThreadReference.get().stop();
+                                senderThread.stop();
                             }
 
                             @Override

--- a/src/test/java/org/graylog2/gelfclient/transport/AbstractGelfTransportTest.java
+++ b/src/test/java/org/graylog2/gelfclient/transport/AbstractGelfTransportTest.java
@@ -34,6 +34,11 @@ public class AbstractGelfTransportTest {
                 final NioEventLoopGroup eventLoopGroup = (NioEventLoopGroup) workerGroup;
                 assertEquals(threads, eventLoopGroup.executorCount());
             }
+
+            @Override
+            public void flushAndStop() {
+                // Nothing do to here.
+            }
         };
         transport.stop();
     }

--- a/src/test/java/org/graylog2/gelfclient/transport/AbstractGelfTransportTest.java
+++ b/src/test/java/org/graylog2/gelfclient/transport/AbstractGelfTransportTest.java
@@ -20,6 +20,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import org.graylog2.gelfclient.GelfConfiguration;
 import org.testng.annotations.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.testng.Assert.assertEquals;
 
 public class AbstractGelfTransportTest {
@@ -36,8 +38,8 @@ public class AbstractGelfTransportTest {
             }
 
             @Override
-            public void flushAndStop() {
-                // Nothing do to here.
+            public void flushAndStopSynchronously(int waitDuration, TimeUnit timeUnit, int retries) {
+                super.flushAndStopSynchronously(waitDuration, timeUnit, retries);
             }
         };
         transport.stop();


### PR DESCRIPTION
Resolves #42.

This change adds a `GelfTransport.flushAndStop()` method which blocks and waits for all messages to flush (send) before allowing shutdown to continue. 

Closes https://github.com/Graylog2/graylog-s3-lambda/issues/2