### PR TITLE
Update netty to 4.1.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.31.Final</version>
+            <version>4.1.42.Final</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Release notes:

- https://netty.io/news/2018/11/29/4-1-32-Final.html
- https://netty.io/news/2019/01/21/4-1-33-Final.html
- https://netty.io/news/2019/03/08/4-1-34-Final.html
- https://netty.io/news/2019/04/17/4-1-35-Final.html
- https://netty.io/news/2019/04/30/4-1-36-Final.html
- https://netty.io/news/2019/06/28/4-1-37-Final.html
- https://netty.io/news/2019/07/24/4-1-38-Final.html
- https://netty.io/news/2019/08/13/4-1-39-Final.html
- (there was no 4.1.40 release)
- https://netty.io/news/2019/09/12/4-1-41-Final.html
- https://netty.io/news/2019/09/25/4-1-42-Final.html