### PR TITLE
Update netty-handler to latest version 4.1.59.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.59.Final</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Update the `netty-handler` dependency to `4.1.59.Final`. This resolves an important CVE as mentioned in #50. I'm not sure why Dependabot did not pick up the later version, so this PR was filed.